### PR TITLE
fix when publishing to wordpress, it will  lose the image size info in the img tag

### DIFF
--- a/src/abstract-wp-client.ts
+++ b/src/abstract-wp-client.ts
@@ -224,7 +224,13 @@ export abstract class AbstractWordPressClient implements WordPressClient {
               content: content
             }, auth);
             if (result.code === WordPressClientReturnCode.OK) {
-              postParams.content = postParams.content.replace(img.original, `![${imgFile.name}](${result.data.url})`);
+              if(img.width && img.height){
+                  postParams.content = postParams.content.replace(img.original, `![[${result.data.url}|${img.width}x${img.height}]]`);
+              }else if (img.width){
+                  postParams.content = postParams.content.replace(img.original, `![[${result.data.url}|${img.width}]]`);
+              }else{
+                  postParams.content = postParams.content.replace(img.original, `![[${result.data.url}]]`);
+              }
             } else {
               if (result.error.code === WordPressClientReturnCode.ServerInternalError) {
                 new Notice(result.error.message, ERROR_NOTICE_TIMEOUT);
@@ -262,7 +268,7 @@ export abstract class AbstractWordPressClient implements WordPressClient {
       // read note title, content and matter data
       const title = file.basename;
       const { content, matter: matterData } = await processFile(file, this.plugin.app);
-
+      
       // check if profile selected is matched to the one in note property,
       // if not, ask whether to update or not
       await this.checkExistingProfile(matterData);


### PR DESCRIPTION
fix when publishing to wordpress, it will bypass the markdown-image-plugin and lose the image size info

for example
`![[Pasted image 20250219174543.png|640]]`
will turn into 
`![Pasted image 20250219174543.png](url)`
then render into html
`<img src="https://your-domain.com/wp-content/uploads/20250219174543.png" >`
the size info is lose, and the markdown-image plugin will do nothing.

I fixed it by  make  `![[Pasted image 20250219174543.png|640]]` turn into `![[https://your-domain.com/wp-content/uploads/20250219174543.png|640]`
so later the img tag will have the size info